### PR TITLE
update_6.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ about:
     can be easily added, for example to cover NumPy docstring conventions.
     pydocstyle supports Python 3.6 and higher.
   doc_url: https://www.pydocstyle.org/en/stable/
-  dev_url: https://github.com/PyCQA/pydocstyle
+  dev_url: https://github.com/PyCQA/pydocstyle 
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,11 +12,10 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: True # [py<38]
+  skip: True # [py<36]
   number: 0
   entry_points:
     - pydocstyle = pydocstyle.cli:main
-
 
 requirements:
   host:
@@ -25,11 +24,11 @@ requirements:
     - setuptools
     - wheel
     - poetry-core
-
   run:
     - python
     - snowballstemmer >=2.2.0
-    - tomli >=1.2.3
+    - tomli >=1.2.3  # [py<311]
+    - importlib-metadata >=2.0.0,<5.0.0  # [py<38]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: True # [py<38]
+  skip: True # [py<37]
   number: 0
   entry_points:
     - pydocstyle = pydocstyle.cli:main
@@ -39,7 +39,7 @@ test:
   commands:
     - pip check
     - pydocstyle --version
-    
+
 about:
   home: https://github.com/PyCQA/pydocstyle
   license: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,9 +51,9 @@ about:
     but it should not be considered a reference implementation.
     The framework for checking docstring style is flexible, and custom checks
     can be easily added, for example to cover NumPy docstring conventions.
-    pydocstyle supports Python 3.6 and higher.
+    pydocstyle supports Python 3.7 through 3.11.
   doc_url: https://www.pydocstyle.org/en/stable/
-  dev_url: https://github.com/PyCQA/pydocstyle 
+  dev_url: https://github.com/PyCQA/pydocstyle
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: True # [py<37]
+  skip: True # [py<38]
   number: 0
   entry_points:
     - pydocstyle = pydocstyle.cli:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ about:
     but it should not be considered a reference implementation.
     The framework for checking docstring style is flexible, and custom checks
     can be easily added, for example to cover NumPy docstring conventions.
-    pydocstyle supports Python 3.4, 3.5, 3.6, and 3.7.
+    pydocstyle supports Python 3.6 and higher.
   doc_url: https://www.pydocstyle.org/en/stable/
   dev_url: https://github.com/PyCQA/pydocstyle
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pydocstyle" %}
-{% set version = "6.1.1" %}
-{% set hash = "1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc" %}
+{% set version = "6.3.0" %}
+{% set hash = "7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1" %}
 
 package:
   name: {{ name }}
@@ -11,8 +11,8 @@ source:
   sha256: {{ hash }}
 
 build:
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True # [py<38]
   number: 0
   entry_points:
     - pydocstyle = pydocstyle.cli:main
@@ -21,11 +21,15 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
+    - poetry-core
 
   run:
-    - python >=3.6
-    - snowballstemmer
+    - python
+    - snowballstemmer >=2.2.0
+    - tomli >=1.2.3
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,9 +34,12 @@ requirements:
 test:
   imports:
     - pydocstyle
+  requires:
+    - pip
   commands:
+    - pip check
     - pydocstyle --version
-
+    
 about:
   home: https://github.com/PyCQA/pydocstyle
   license: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ test:
 about:
   home: https://github.com/PyCQA/pydocstyle
   license: MIT
+  license_url: https://github.com/PyCQA/pydocstyle/blob/master/LICENSE-MIT
   license_file: LICENSE-MIT
   summary: Python docstring style checker (formerly pep257)
   description: |
@@ -49,7 +50,7 @@ about:
     The framework for checking docstring style is flexible, and custom checks
     can be easily added, for example to cover NumPy docstring conventions.
     pydocstyle supports Python 3.4, 3.5, 3.6, and 3.7.
-  doc_url: http://pydocstyle.readthedocs.org
+  doc_url: https://www.pydocstyle.org/en/stable/
   dev_url: https://github.com/PyCQA/pydocstyle
 
 extra:


### PR DESCRIPTION
## Version Bump to 6.3.0
- [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-1034)
- [Upstream](https://github.com/PyCQA/pydocstyle)
# Changes
- Updated checksum and version number
- Added `setuptools` and `wheel` to `host` section
- Amendment to run section dependency pinnings
- Support for python versions 3.6 or higher
- Updated links for `about` section