### PR TITLE
pydocstyle 6.3.0 (314 rebuild)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,20 @@
 {% set name = "pydocstyle" %}
 {% set version = "6.3.0" %}
-{% set hash = "7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ hash }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1
 
 build:
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: True # [py<36]
-  number: 0
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - pydocstyle = pydocstyle.cli:main
+  skip: true # [py<36]
 
 requirements:
   host:
@@ -27,8 +26,9 @@ requirements:
   run:
     - python
     - snowballstemmer >=2.2.0
-    - tomli >=1.2.3  # [py<311]
     - importlib-metadata >=2.0.0,<5.0.0  # [py<38]
+  run_constrained:
+    - tomli >=1.2.3  # [py<311]
 
 test:
   imports:
@@ -52,7 +52,7 @@ about:
     The framework for checking docstring style is flexible, and custom checks
     can be easily added, for example to cover NumPy docstring conventions.
     pydocstyle supports Python 3.7 through 3.11.
-  doc_url: https://www.pydocstyle.org/en/stable/
+  doc_url: https://www.pydocstyle.org/en/stable
   dev_url: https://github.com/PyCQA/pydocstyle
 
 extra:


### PR DESCRIPTION
pydocstyle 6.3.0 

**Destination channel:** Defaults

### Links

- [PKG-11837]
- dev_url:        https://github.com/PyCQA/pydocstyle/tree/6.3.0
- conda_forge:    https://github.com/conda-forge/pydocstyle-feedstock
- pypi:           https://pypi.org/project/pydocstyle/6.3.0
- pypi inspector: https://inspector.pypi.io/project/pydocstyle/6.3.0

### Explanation of changes:

- rebuild for py314


[PKG-11837]: https://anaconda.atlassian.net/browse/PKG-11837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ